### PR TITLE
[feat/users-create_domain] UserEntity 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,11 +22,18 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// db
 	runtimeOnly 'com.h2database:h2'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	// lombok
 	annotationProcessor 'org.projectlombok:lombok'
+	compileOnly 'org.projectlombok:lombok'
+
+	// test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/com/thecommerce/userproduct/domain/user/User.java
+++ b/src/main/java/com/thecommerce/userproduct/domain/user/User.java
@@ -1,0 +1,31 @@
+package com.thecommerce.userproduct.domain.user;
+
+import java.time.LocalDateTime;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.validation.constraints.Email;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class User {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	@Email
+	private String emailId;
+	private String password;
+	private String nickname;
+	private String username;
+	private LocalDateTime createdAt;
+	private LocalDateTime modifiedAt;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: UserProduct
   datasource:
-    url: jdbc:h2:mem:the-commerce
+    url: jdbc:h2:mem:the-commerce;NON_KEYWORDS=USER
     username: sa
     password:
     driver-class-name: org.h2.Driver


### PR DESCRIPTION
## Change

- 요구 사항의 email 주소의 신뢰를 위해 validate 의존성 추가 후 @Email 어노테이션으로 유효성 검사

## Background

- h2 2.x버전에 User가 예약어가 됐기 때문에 NON_KEYWORDS=USER 으로 해결 후 User Table 생성