### PR TITLE
[feat/user-get_users-1] 회원정보 목록 보기 기능 테스트코드 작성

### DIFF
--- a/src/main/java/com/thecommerce/userproduct/controller/test/TestController.java
+++ b/src/main/java/com/thecommerce/userproduct/controller/test/TestController.java
@@ -1,0 +1,33 @@
+package com.thecommerce.userproduct.controller.test;
+
+import com.thecommerce.userproduct.domain.user.entity.User;
+import com.thecommerce.userproduct.domain.user.repository.UserRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TestController {
+
+	private final UserRepository userRepository;
+
+	@PostMapping("/test")
+	public void create() {
+		List<User> users = new ArrayList<>();
+		for (int i = 0; i < 100; i++) {
+			users.add(User.builder()
+				.userId("sunsik" + i)
+				.username(i + "")
+				.nickname("nick" + i)
+				.mobileNumber("010" + i)
+				.email("ss@ss.com" + i)
+				.password("1234")
+				.build());
+		}
+		userRepository.saveAll(users);
+	}
+
+}

--- a/src/main/java/com/thecommerce/userproduct/domain/BaseEntity.java
+++ b/src/main/java/com/thecommerce/userproduct/domain/BaseEntity.java
@@ -3,9 +3,6 @@ package com.thecommerce.userproduct.domain;
 
 import java.time.LocalDateTime;
 import javax.persistence.EntityListeners;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -20,10 +17,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public class BaseEntity {
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
-
 	@CreatedDate
 	private LocalDateTime createdAt;
 	@LastModifiedDate

--- a/src/main/java/com/thecommerce/userproduct/domain/user/entity/User.java
+++ b/src/main/java/com/thecommerce/userproduct/domain/user/entity/User.java
@@ -4,8 +4,13 @@ import static com.thecommerce.userproduct.exception.contants.ErrorCode.NEED_TO_C
 
 import com.thecommerce.userproduct.domain.BaseEntity;
 import com.thecommerce.userproduct.exception.UserServiceException;
+import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import javax.validation.constraints.Email;
+import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,12 +22,22 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class User extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(unique = true, nullable = false)
 	private String userId;
+	@NotNull
 	private String password;
+	@Column(unique = true, nullable = false)
 	private String nickname;
+	@NotNull
 	private String username;
+	@Column(unique = true, nullable = false)
 	private String mobileNumber;
 	@Email
+	@Column(unique = true, nullable = false)
 	private String email;
 
 	public void update(String newNickname, String newMobileNum, String newEmail) {

--- a/src/main/java/com/thecommerce/userproduct/service/user/UserReadService.java
+++ b/src/main/java/com/thecommerce/userproduct/service/user/UserReadService.java
@@ -21,8 +21,8 @@ public class UserReadService {
 
 		Long nextKey = users.isEmpty() ? null :
 			users.stream()
-			.mapToLong(User::getId)
-			.max().orElse(PageResult.NON_KEY);
+				.mapToLong(User::getId)
+				.max().orElse(PageResult.NON_KEY);
 
 		return new PageResult<>(
 			users.stream()

--- a/src/test/java/com/thecommerce/userproduct/service/user/UserReadServiceTest.java
+++ b/src/test/java/com/thecommerce/userproduct/service/user/UserReadServiceTest.java
@@ -1,0 +1,109 @@
+package com.thecommerce.userproduct.service.user;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import com.thecommerce.userproduct.domain.user.dto.UserDto;
+import com.thecommerce.userproduct.domain.user.entity.User;
+import com.thecommerce.userproduct.domain.user.repository.UserRepository;
+import com.thecommerce.userproduct.util.PageResult;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+@ExtendWith(MockitoExtension.class)
+public class UserReadServiceTest {
+
+	@Mock
+	private UserRepository userRepository;
+
+	@InjectMocks
+	private UserReadService userReadService;
+
+	@Test
+	@DisplayName("유저 목록 조회 - 마지막 페이지")
+	void getUsersHasNextTrue() {
+		//given
+		List<User> users = createUserList();
+		given(userRepository.findAll(any(Pageable.class)))
+			.willReturn(new PageImpl<>(users));
+		given(userRepository.existsByIdGreaterThan(anyLong()))
+			.willReturn(false);
+		//when
+		PageResult<UserDto> result = userReadService.getUsers(
+			PageRequest.of(0, 10, Sort.by("createdAt")));
+		//then
+		assertFalse(result.isHasNext());
+		assertEquals(result.getBody().size(), 10);
+		assertEquals(result.getBody().get(0).getUserId(), "nss0");
+		assertEquals(result.getBody().get(0).getUsername(), "sunsik0");
+		assertEquals(result.getBody().get(0).getNickname(), "nj0");
+		assertEquals(result.getBody().get(0).getMobileNumber(), "0100");
+		assertEquals(result.getBody().get(0).getEmail(), "ss@gmail.com0");
+		assertEquals(result.getBody().get(9).getUserId(), "nss9");
+		assertEquals(result.getBody().get(9).getUsername(), "sunsik9");
+		assertEquals(result.getBody().get(9).getNickname(), "nj9");
+		assertEquals(result.getBody().get(9).getMobileNumber(), "0109");
+		assertEquals(result.getBody().get(9).getEmail(), "ss@gmail.com9");
+	}
+
+	@Test
+	@DisplayName("유저 목록 조회 - 다음 페이지 존재")
+	void getUsersHasNextFalse() {
+		//given
+		List<User> users = createUserList();
+		given(userRepository.findAll(any(Pageable.class)))
+			.willReturn(new PageImpl<>(users.subList(0, 5)));
+		given(userRepository.existsByIdGreaterThan(anyLong()))
+			.willReturn(true);
+
+		//when
+		PageResult<UserDto> result = userReadService.getUsers(
+			PageRequest.of(0, 5, Sort.by("createdAt"))
+		);
+		//then
+		assertTrue(result.isHasNext());
+		assertEquals(result.getBody().size(), 5);
+		assertEquals(result.getBody().get(0).getUserId(), "nss0");
+		assertEquals(result.getBody().get(0).getUsername(), "sunsik0");
+		assertEquals(result.getBody().get(0).getNickname(), "nj0");
+		assertEquals(result.getBody().get(0).getMobileNumber(), "0100");
+		assertEquals(result.getBody().get(0).getEmail(), "ss@gmail.com0");
+		assertEquals(result.getBody().get(4).getUserId(), "nss4");
+		assertEquals(result.getBody().get(4).getUsername(), "sunsik4");
+		assertEquals(result.getBody().get(4).getNickname(), "nj4");
+		assertEquals(result.getBody().get(4).getMobileNumber(), "0104");
+		assertEquals(result.getBody().get(4).getEmail(), "ss@gmail.com4");
+	}
+
+	private List<User> createUserList() {
+		List<User> users = new ArrayList<>();
+		for (int i = 0; i < 10; i++) {
+			users.add(
+				User.builder()
+					.id((long) i)
+					.userId("nss" + i)
+					.password("1234")
+					.username("sunsik" + i)
+					.email("ss@gmail.com" + i)
+					.nickname("nj" + i)
+					.mobileNumber("010" + i)
+					.build()
+			);
+		}
+		return users;
+	}
+}


### PR DESCRIPTION
## Change

- 테스트를 위해 유저 100개 생성하는 컨트롤러 생성

- 테스트를 위해 BaseEntity에서 id 제거
  - entity에 id 추가
  - entity properties null 방지

- 테스트 코드 추가